### PR TITLE
fixed command line arguments passing to stitcher class

### DIFF
--- a/alignImagesRansac.py
+++ b/alignImagesRansac.py
@@ -353,8 +353,8 @@ class AlignImagesRansac(object):
 
  # ----------------------------------------------------------------------------
 if __name__ == '__main__':
-    if ( len(args) < 4 ):
-        print >> sys.stderr, ("Usage: %s <image_dir> <key_frame> <output>" % args[0])
+    if ( len(sys.argv) < 4 ):
+        print >> sys.stderr, ("Usage: %s <image_dir> <key_frame> <output>" % sys.argv[0])
         sys.exit(-1)
-    AlignImagesRansac(sys.args[1:])
+    AlignImagesRansac(*sys.argv[1:])
 


### PR DESCRIPTION
'args'  which is supposed to have the arguments passed from command line  has been changed to sys.argv. The sys.argv returns a list of the arguments hence it is necessary to unpack the list and send them to the stitcher class. 
